### PR TITLE
Fix error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ dilation_patch=2
 ## Example
 ```python
 import torch
-from spatial_correlation_sampler import SpatialCorrelationSampler, 
+from spatial_correlation_sampler import SpatialCorrelationSampler, spatial_correlation_sample
 
 device = "cuda"
 batch_size = 1


### PR DESCRIPTION
Fixes an `NameError` in the example code snippet of the README.

```
python sample.py 
Traceback (most recent call last):
  File "/home/xxx/sample.py", line 18, in <module>
    out = spatial_correlation_sample(input1,
NameError: name 'spatial_correlation_sample' is not defined. Did you mean: 'SpatialCorrelationSampler'?
```