### PR TITLE
Update spatial_correlation_sampler.py

### DIFF
--- a/Correlation_Module/spatial_correlation_sampler/spatial_correlation_sampler.py
+++ b/Correlation_Module/spatial_correlation_sampler/spatial_correlation_sampler.py
@@ -74,7 +74,7 @@ class SpatialCorrelationSamplerFunction(Function):
     @staticmethod
     @once_differentiable
     def backward(ctx, grad_output):
-        input1, input2 = ctx.saved_variables
+        input1, input2 = ctx.saved_tensors
 
         kH, kW = ctx.kernel_size
         patchH, patchW = ctx.patch_size


### PR DESCRIPTION
Changed `ctx.saved_variables` to `ctx.saved_tensors` in backward of `SpatialCorrelationSamplerFunction` under [`spatial_correlation_sampler/spatial_correlation_sampler.py`](https://github.com/ClementPinard/Pytorch-Correlation-extension/blob/44da76d5c7e97e16860660cf28b85056b2f17c79/Correlation_Module/spatial_correlation_sampler/spatial_correlation_sampler.py#L76) since `saved_variables` is deprecated